### PR TITLE
chore: bump to latest patch for cert-manager v1.12.3

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 appVersion: v0.1.0
 description: GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expects CRDs to be installed using another method
 name: glueops-cert-manager
-version: 0.8.1
+version: 0.8.2
 dependencies:
   - name: cert-manager
-    version: v1.12.2
+    version: v1.12.3
     repository: https://charts.jetstack.io
 


### PR DESCRIPTION
https://github.com/cert-manager/cert-manager/releases/tag/v1.12.3