### PR TITLE
chore: cert-manager v1.12.5 -> v1.13.2, glueops-cert-manager: 0.8.4 -…

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 appVersion: v0.1.0
 description: GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expects CRDs to be installed using another method
 name: glueops-cert-manager
-version: 0.8.4
+version: 0.9.0
 dependencies:
   - name: cert-manager
-    version: v1.12.5
+    version: v1.13.2
     repository: https://charts.jetstack.io
 


### PR DESCRIPTION
…>  0.9.0