### PR TITLE
chore: bump for release

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.1.0
 description: GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expects CRDs to be installed using another method
 name: glueops-cert-manager
-version: 0.12.1
+version: 0.12.2
 dependencies:
   - name: cert-manager
     version: v1.13.6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-cert-manager
 
-![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.12.2](https://img.shields.io/badge/Version-0.12.2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expects CRDs to be installed using another method
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- This PR updates the Helm chart version for `glueops-cert-manager` from `0.12.1` to `0.12.2`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Update Helm Chart Version for glueops-cert-manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Chart.yaml
- Bumped the version of the Helm chart from 0.12.1 to 0.12.2.


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-cert-manager/pull/38/files#diff-d954583aa4c24cff0039bc948abd7c694fc3dab2030231d11ed1b3cda9b4ddbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

