### PR TITLE
major: removing image definition from cert restore job so that it's nil and needs to be configured when using this helm chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.1.0
 description: GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expects CRDs to be installed using another method
 name: glueops-cert-manager
-version: 0.16.6
+version: 0.16.7
 dependencies:
   - name: cert-manager
     version: v1.16.4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-cert-manager
 
-![Version: 0.16.6](https://img.shields.io/badge/Version-0.16.6-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.16.7](https://img.shields.io/badge/Version-0.16.7-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expects CRDs to be installed using another method
 
@@ -23,3 +23,4 @@ GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expe
 | cert-manager.webhook.hostNetwork | bool | `true` |  |
 | cert-manager.webhook.readinessProbe.initialDelaySeconds | int | `120` |  |
 | cert-manager.webhook.securePort | int | `10750` |  |
+| cert-restore.image | string | `"nil"` |  |

--- a/templates/cert-restore-job.yaml
+++ b/templates/cert-restore-job.yaml
@@ -37,7 +37,7 @@ spec:
           value: {{ index (index .Values "cert-restore") "backup_prefix" }}
         - name: EXCLUDE_NAMESPACES
           value: {{ index (index .Values "cert-restore") "exclude_namespaces" }}
-        image: ghcr.io/glueops/certs-backup-restore:v0.10.1@sha256:71c22ce97be9daddbfab90a26a59a900c00c18daec361c806918e52903513238
+        image: {{ index (index .Values "cert-restore") "image" }}
         imagePullPolicy: IfNotPresent
         name: glueops-tls-cert-restore
         resources:

--- a/values.yaml
+++ b/values.yaml
@@ -15,3 +15,5 @@ cert-manager:
       initialDelaySeconds: 120
   crds:
     enabled: true
+cert-restore:
+  image: nil


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Parameterized the `cert-restore` job image in Helm chart.

- Updated Helm chart version to `0.16.7`.

- Added `cert-restore.image` configuration in `values.yaml`.

- Updated documentation to reflect new chart version and configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Bumped Helm chart version to 0.16.7</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Chart.yaml

- Updated chart version from `0.16.6` to `0.16.7`.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-cert-manager/pull/71/files#diff-d954583aa4c24cff0039bc948abd7c694fc3dab2030231d11ed1b3cda9b4ddbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Added cert-restore.image configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

values.yaml

- Added `cert-restore.image` configuration with default value `nil`.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-cert-manager/pull/71/files#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Updated README with new version and configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated version badge to reflect chart version <code>0.16.7</code>.<br> <li> Added documentation for <code>cert-restore.image</code> configuration.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-cert-manager/pull/71/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cert-restore-job.yaml</strong><dd><code>Parameterized cert-restore job image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/cert-restore-job.yaml

- Replaced hardcoded image with parameterized `cert-restore.image`.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-cert-manager/pull/71/files#diff-41e88c789de33a51581947f715428591f76e67d111a8364627190205d9717d6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>