### PR TITLE
fix: missed references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-cert-manager
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.17.1](https://img.shields.io/badge/Version-0.17.1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expects CRDs to be installed using another method
 

--- a/templates/certificates.yaml
+++ b/templates/certificates.yaml
@@ -6,8 +6,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "1"
 spec:
   dnsNames:
-  - '*.apps.{{ index (index .Values "cert-manager") "captain_domain" }}'
-  - '*.{{ index (index .Values "cert-manager") "captain_domain" }}'
+  - '*.apps.{{ .Values.cert_manager_glueops_specifics.captain_domain }}'
+  - '*.{{ .Values.cert_manager_glueops_specifics.captain_domain }}'
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect references in `certificates.yaml`.

- Replaced `cert-manager` references with `cert_manager_glueops_specifics`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>certificates.yaml</strong><dd><code>Fix DNS name references in certificates.yaml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/certificates.yaml

<li>Corrected DNS name references to use <code>cert_manager_glueops_specifics</code>.<br> <li> Replaced <code>cert-manager</code> with <code>cert_manager_glueops_specifics</code> for <br>consistency.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-cert-manager/pull/77/files#diff-89df589c052a4ab96b0ea79a2fa7515e9ea16dfc007c1b5822fa1d372ae07fa7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>