### PR TITLE
refactor to adopt restoring specific backup

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.1.0
 description: GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expects CRDs to be installed using another method
 name: glueops-cert-manager
-version: 0.17.1
+version: 0.17.2
 dependencies:
   - name: cert-manager
     version: v1.16.4

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.1.0
 description: GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expects CRDs to be installed using another method
 name: glueops-cert-manager
-version: 0.17.2
+version: 0.18.0
 dependencies:
   - name: cert-manager
     version: v1.16.4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-cert-manager
 
-![Version: 0.17.2](https://img.shields.io/badge/Version-0.17.2-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 GlueOps Helm Chart for cert-manager with sensible defaults. This chart also expects CRDs to be installed using another method
 

--- a/templates/cert-restore-job.yaml
+++ b/templates/cert-restore-job.yaml
@@ -35,6 +35,8 @@ spec:
           value: {{ .Values.cert_restore.bucket_name }}
         - name: BACKUP_PREFIX
           value: {{ .Values.cert_restore.backup_prefix }}
+        - name: RESTORE_THIS_BACKUP
+          value: {{ .Values.cert_restore.restore_this_backup }}
         - name: EXCLUDE_NAMESPACES
           value: {{ .Values.cert_restore.exclude_namespaces }}
         image: {{ .Values.cert_restore.image }}

--- a/values.yaml
+++ b/values.yaml
@@ -27,4 +27,5 @@ cert_restore:
   captain_domain: nil
   bucket_name: nil
   backup_prefix: nil
+  restore_this_backup: nil
   exclude_namespaces: nil


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Add support for restoring a specific backup via new variable

- Update Helm template and values to include `restore_this_backup`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cert-restore-job.yaml</strong><dd><code>Add RESTORE_THIS_BACKUP env variable to restore job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/cert-restore-job.yaml

<li>Add <code>RESTORE_THIS_BACKUP</code> environment variable to the restore job<br> <li> Reference new value from Helm values file


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-cert-manager/pull/80/files#diff-41e88c789de33a51581947f715428591f76e67d111a8364627190205d9717d6a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add restore_this_backup to cert_restore values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

values.yaml

<li>Add <code>restore_this_backup</code> field under <code>cert_restore</code> configuration<br> <li> Set default value to nil


</details>


  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-cert-manager/pull/80/files#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>